### PR TITLE
<Fix> : 누락된 Socket 추가

### DIFF
--- a/TeamProject/GameProject/Model.cpp
+++ b/TeamProject/GameProject/Model.cpp
@@ -53,6 +53,10 @@ namespace SSB
 	{
 		_boundingVolume = data;
 	}
+	void Model::Initialize_RegisterSocket(SocketName name, BoneIndex index)
+	{
+		_sockets.insert(std::make_pair(name, index));
+	}
 	void Model::SetCurrentAnimation(AnimationName name)
 	{
 		if (_animations.find(name) != _animations.end())
@@ -78,6 +82,14 @@ namespace SSB
 	void Model::SetPixelShader(Shader* shader)
 	{
 		_ps = shader;
+	}
+	TMatrix Model::GetSocketCurrentMatrix(SocketName name)
+	{
+		if (_sockets.find(name) != _sockets.end())
+		{
+			return _currentAnimation->GetCurrentBoneMatrix(_sockets.find(name)->second);
+		}
+		return TMatrix();
 	}
 	OBBData Model::GetBoundingVolume()
 	{
@@ -187,6 +199,23 @@ namespace SSB
 			XMFLOAT3 tmp;
 			Serializeable::Deserialize(data.str, tmp);
 			_maxVertex = tmp;
+		}
+
+		{
+			offset = serialedString.find(_socketDataStr);
+			auto data = GetUnitElement(serialedString, offset);
+			offset = data.offset;
+			int socketCount;
+			Serializeable::Deserialize(data.str, socketCount);
+			for (int i = 0; i < socketCount; ++i)
+			{
+				auto socketNameData = GetUnitAtomic(serialedString, offset);
+				offset = socketNameData.offset;
+				auto boneIndexData = GetUnitAtomic(serialedString, offset);
+				offset = boneIndexData.offset;
+
+				_sockets.insert(std::make_pair(socketNameData.str, std::stoi(boneIndexData.str)));
+			}
 		}
 
 		offset = serialedString.find(_boundingVolumeStr);

--- a/TeamProject/GameProject/Model.h
+++ b/TeamProject/GameProject/Model.h
@@ -12,6 +12,8 @@
 
 namespace SSB
 {
+	typedef std::string SocketName;
+
 	struct OBBData
 	{
 		TVector3 Position;
@@ -46,6 +48,8 @@ namespace SSB
 
 		OBBData _boundingVolume;
 
+		std::map<SocketName, BoneIndex> _sockets;
+
 	public:
 		Model();
 		virtual ~Model();
@@ -58,11 +62,13 @@ namespace SSB
 		void Initialize_RegisterMesh(MeshIndex index, MeshInterface* mesh);
 		void Initialize_RegisterAnimation(AnimationName name, Animation* animation);
 		void Initialize_SetBoundingVolume(OBBData data);
+		void Initialize_RegisterSocket(SocketName name, BoneIndex index);
 
 	public:
 		void SetCurrentAnimation(AnimationName name);
 		void SetVertexShader(Shader* shader);
 		void SetPixelShader(Shader* shader);
+		TMatrix GetSocketCurrentMatrix(SocketName name);
 		OBBData GetBoundingVolume();
 
 	public:

--- a/TeamProject/GameProject/Serializeable.h
+++ b/TeamProject/GameProject/Serializeable.h
@@ -12,6 +12,7 @@ namespace SSB
 	public:
 		std::string _minVertexStr = "Min Vertex\n";
 		std::string _maxVertexStr = "Max Vertex\n";
+		std::string _socketDataStr = "Socket Data : ";
 		std::string _boundingVolumeStr = "OBB Data : ";
 		std::string _materialStr = "Material\n";
 		std::string _materialIndexStr = "Material Index : ";


### PR DESCRIPTION
Garen에 WeaponEnd라는 Socket을 예시로 추가해놨습니다.
Garen의 검 끝에 위치한 Socket입니다.
Character의 Model::GetSocketCurrentMatrix()를 통해서 접근이 가능합니다. 접근하게 되면 현재 Animation의 Socket의 World Matrix가 반환됩니다.